### PR TITLE
Update to fix deprecated version of Android embedding

### DIFF
--- a/app/android/app/src/main/AndroidManifest.xml
+++ b/app/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
          FlutterApplication and put your custom class here. -->
     <uses-permission android:name="android.permission.INTERNET"/> 
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="${applicationName}"
         android:label="app"
         android:icon="@mipmap/ic_launcher">
         <activity


### PR DESCRIPTION
To fix https://github.com/GeekyAnts/flutter-starter/issues/27

With this fix, flutter run does not fail on my M1 MacBook Pro with newly installed flutter, Xcode, and Android Studio (although Android Studio was not required for this fix not to crash flutter run).  